### PR TITLE
Update to v1.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endif
 
 BUILD_META=-build$(shell date +%Y%m%d)
 ORG ?= rancher
-TAG ?= v0.9.1$(BUILD_META)
+TAG ?= v1.0.1$(BUILD_META)
 
 ifneq ($(DRONE_TAG),)
 TAG := $(DRONE_TAG)


### PR DESCRIPTION
In version v1.0.1 of https://github.com/containernetworking/plugins, flannel is not part of it. We need the binary from its own repo

Signed-off-by: Manuel Buil <mbuil@suse.com>