### PR TITLE
More generically assert go boring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,18 +31,12 @@ RUN git clone --depth=1 https://github.com/flannel-io/cni-plugin $GOPATH/src/git
 WORKDIR $GOPATH/src/github.com/containernetworking/plugins
 RUN go-assert-static.sh bin/* && \
     if [ "${ARCH}" = "amd64" ]; then \
-        go-assert-boring.sh bin/bandwidth \
-        bin/bridge \
-        bin/dhcp \
-        bin/firewall \
-        bin/host-device \
-        bin/host-local \
-        bin/ipvlan \
-        bin/macvlan \
-        bin/portmap \
-        bin/ptp \
-        bin/vlan ; \
-    fi && \
+        for file in bin/*; do \
+          if [ $(go tool nm $file | grep crypto | wc -l) != 0 ]; then \
+            go-assert-boring.sh $file; \
+          fi; \
+        done; \
+    fi; \
     mkdir -vp /opt/cni/bin && \
     install -D -s bin/* /opt/cni/bin
 


### PR DESCRIPTION
Currently, we do not assert go boring in binaries that do not have calls to crypto functions because the results would be irrelevant and lead to false negatives. This is a good approach, however it is not apparent in the code and there is no documentation giving the reason for some binaries to be left from the go-assert-boring call.

While these binaries might not change very often, if a binary is added by the upstream vendor and should be checked for go crypto, we would need to be aware and make a code change in the current version. This patch removes that concern, making the code self-document the reason for the missing binaries and include any binaries that might be added in the future (future proofing a bit). 

There is always some inherent risk in accepting any change into a repo, and this change doesn't change the outcome of the process it only makes the outcomes more clear to the reader while also improving reliability by making the script more agile to change in the upstream dependency, as such, don't hesitate to deny this request if you feel the value it adds isn't worth the risk.

<details><summary>Testing Details</summary>

Passing local build:
```
Dev: root@dev image-build-cni-plugins [verify-flannel-boring] docker build --no-cache -t testscancniplugins .
[+] Building 50.1s (15/15) FINISHED                                                                                                                                                                                                 
 => [internal] load build definition from Dockerfile                                                                                                                                                                           0.0s
 => => transferring dockerfile: 1.88kB                                                                                                                                                                                         0.0s
 => [internal] load .dockerignore                                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                                0.0s
 => [internal] load metadata for registry.suse.com/bci/bci-base:latest                                                                                                                                                         0.7s
 => [internal] load metadata for docker.io/rancher/hardened-build-base:v1.20.4b11                                                                                                                                              0.5s
 => [auth] rancher/hardened-build-base:pull token for registry-1.docker.io                                                                                                                                                     0.0s
 => CACHED [cni_plugins 1/5] FROM docker.io/rancher/hardened-build-base:v1.20.4b11@sha256:858b479206118dd2965ab5282753da1fa8f7f85793e7caeae85fa3a0e2da5516                                                                     0.0s
 => [internal] load build context                                                                                                                                                                                              0.0s
 => => transferring context: 37B                                                                                                                                                                                               0.0s
 => CACHED [stage-1 1/4] FROM registry.suse.com/bci/bci-base@sha256:6cbfea5ca77c23735b84c82cef6a245a70716ed7988cbd2dc5278824616b21d9                                                                                           0.0s
 => [cni_plugins 2/5] RUN git clone --depth=1 https://github.com/containernetworking/plugins.git /go/src/github.com/containernetworking/plugins &&     cd /go/src/github.com/containernetworking/plugins &&     git fetch --  39.7s
 => [cni_plugins 3/5] RUN git clone --depth=1 https://github.com/flannel-io/cni-plugin /go/src/github.com/flannel-io/cni-plugin &&     cd /go/src/github.com/flannel-io/cni-plugin &&     git fetch --all --tags --prune &&    5.6s 
 => [cni_plugins 4/5] WORKDIR /go/src/github.com/containernetworking/plugins                                                                                                                                                   0.0s 
 => [cni_plugins 5/5] RUN go-assert-static.sh bin/* &&     if [ "amd64" = "amd64" ]; then         for file in bin/*; do           if [ $(go tool nm $file | grep crypto | wc -l) != 0 ]; then             go-assert-boring.sh  2.9s 
 => [stage-1 2/4] COPY --from=cni_plugins /opt/cni/ /opt/cni/                                                                                                                                                                  0.3s 
 => [stage-1 3/4] COPY install-cnis.sh .                                                                                                                                                                                       0.0s 
 => exporting to image                                                                                                                                                                                                         0.5s 
 => => exporting layers                                                                                                                                                                                                        0.5s 
 => => writing image sha256:d8f40b9d252d182bdbe3eb9eed7c7497174100ac79632e42bbf8ddf04d774778                                                                                                                                   0.0s 
 => => naming to docker.io/library/testscancniplugins
```
trivy scan on above build
```
Dev: root@dev image-build-cni-plugins [verify-flannel-boring] trivy image --scanners vuln -s HIGH,CRITICAL testscancniplugins
2023-06-09T17:59:28.357Z        INFO    Vulnerability scanning is enabled
2023-06-09T17:59:31.215Z        INFO    Detected OS: suse linux enterprise server
2023-06-09T17:59:31.215Z        INFO    Detecting SUSE vulnerabilities...
2023-06-09T17:59:31.217Z        INFO    Number of language-specific files: 18
2023-06-09T17:59:31.217Z        INFO    Detecting gobinary vulnerabilities...

testscancniplugins (suse linux enterprise server 15.4)

Total: 0 (HIGH: 0, CRITICAL: 0)
```
local build targeting intermediate image
```
Dev: root@dev image-build-cni-plugins [verify-flannel-boring] docker build --no-cache --target cni_plugins -t testscancniplugins .
[+] Building 52.9s (9/9) FINISHED                                                                                                                                                                                                   
 => [internal] load .dockerignore                                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                                0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                           0.0s
 => => transferring dockerfile: 1.88kB                                                                                                                                                                                         0.0s
 => [internal] load metadata for docker.io/rancher/hardened-build-base:v1.20.4b11                                                                                                                                              0.2s
 => CACHED [cni_plugins 1/5] FROM docker.io/rancher/hardened-build-base:v1.20.4b11@sha256:858b479206118dd2965ab5282753da1fa8f7f85793e7caeae85fa3a0e2da5516                                                                     0.0s
 => [cni_plugins 2/5] RUN git clone --depth=1 https://github.com/containernetworking/plugins.git /go/src/github.com/containernetworking/plugins &&     cd /go/src/github.com/containernetworking/plugins &&     git fetch --  42.1s
 => [cni_plugins 3/5] RUN git clone --depth=1 https://github.com/flannel-io/cni-plugin /go/src/github.com/flannel-io/cni-plugin &&     cd /go/src/github.com/flannel-io/cni-plugin &&     git fetch --all --tags --prune &&    6.0s
 => [cni_plugins 4/5] WORKDIR /go/src/github.com/containernetworking/plugins                                                                                                                                                   0.1s 
 => [cni_plugins 5/5] RUN go-assert-static.sh bin/* &&     if [ "amd64" = "amd64" ]; then         for file in bin/*; do           if [ $(go tool nm $file | grep crypto | wc -l) != 0 ]; then             go-assert-boring.sh  2.6s 
 => exporting to image                                                                                                                                                                                                         1.8s 
 => => exporting layers                                                                                                                                                                                                        1.8s 
 => => writing image sha256:c1155c50298dc678a7a223e4189736d988d58597770365881ba871c5d67a1dab                                                                                                                                   0.0s 
 => => naming to docker.io/library/testscancniplugins
```
manual go-assert-static validation
```
/go/src/github.com/containernetworking/plugins # go-assert-static.sh bin/*                                                                                                                                                          
bin/bandwidth: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=b797BG_6Zs1XSrae3nvR/Kz7yIW96pA8BQIxypzyY/dkg7pXQnQh9DGUpz4ygR/g3wtHYZIC7hTosTPqBYL, with debug_info, not stripped
bin/bridge: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=82G6f8Ij7Oh35ym6mdcH/rP3ekDhTOgskahu12xkZ/bou745Jg2ZUR8TC7Uq1_/LVO_MpUXo5K3QHa9gODt, with debug_info, not stripped
bin/dhcp: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=gT9V07kr7LGu5Wc4X0GR/ZxKlC-sFl0pL2-rlqU4T/ntWfXs3cwHbMjMlq0uxx/QSXiUPD7j3Y2mzMCem_H, with debug_info, not stripped
bin/dummy: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=1m80nHARbzUOojxj1ADn/uEs72HY8ItOVhWjKD_24/b7d9uhSdD81O0wUXjnEo/Rf0JWGUhVsvSWlnkdUsK, with debug_info, not stripped
bin/firewall: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=xK6R-Z6yWwfRWaUSu4Mh/VObKdbXZNwyi4hViEtHu/lJdJwbNC0xiOLvUr2yYw/5yXTYOe3RBCucvRNuxvs, with debug_info, not stripped
bin/flannel: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=4ybkxN_mZwExQFzofMXD/iMVT8UMalrSu2eJ9lddo/ViCHZZsgqHG1-axR5A-n/aNgArhWjYLbgXHiYLDVD, not stripped
bin/host-device: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=wAJU7YXzMgLaXIODqDWr/i9hhhjV2GGkOr3o4mZvN/-zNsWwofKwksJe9UkYuA/7kpnyjFocaWiVXoBQXNB, with debug_info, not stripped
bin/host-local: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=z2dSqkPFgJRq0vuG5wOx/k3PjckxPzKdWXONsPK97/UgqviY8sNZjwQ_aYOo3D/yljC6ksF3JbqpFwj06G9, with debug_info, not stripped
bin/ipvlan: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=zcLMC-G3a8g3llaeNapr/Oim3E4QzhSiSB0us9OIY/hY_9TVsVj4LJTOJHwILp/Ni1K6JqZnXlS4bvUuiZq, with debug_info, not stripped
bin/loopback: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=Y40Prk9CAjYbFL0OE9L8/pVCk-GJY-X5q2ttyczYz/XjZY5sO_mQ1y8E0BjtKJ/_KHdOV4YiuKjzvo-N9-d, with debug_info, not stripped
bin/macvlan: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=ArLolXDZvRgUZ3BrvRzs/dlB4FTX6mqYSLjicF1Nz/Lp345f8EH9KQ026PcoNm/xpF2IeGdW1PdI0qWranY, with debug_info, not stripped
bin/portmap: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=5SHxXLUgdfRbHeltWh1H/GMPiJrHovv1HOirRKZh2/tndO6qDcIDrBx_iFvLan/SWO0R2jSdf7fFQIW_Jl_, with debug_info, not stripped
bin/ptp: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=4m1TU9NfpJt0bqT23ECa/2C89zhH-0SrkS7GG6pOa/fDrw7kQfDcrX-EWh4MYU/ywlJwoNm_kyn3bLdGQmA, with debug_info, not stripped
bin/sbr: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=iMCYxZpflsmmbKGDGGqK/8z4b4rDwBIf0nc3P4qJ6/kkAL-WHY75s-rCOVUUle/OexwAmWU_SD90kz7zqBX, with debug_info, not stripped
bin/static: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=keek4qgxZSC6jKn0Rs3P/DJi-T0uelMhvWwJt2Hk6/LP0Ooy3nOwIHaGMO5Qti/-yveJJph1V5KWdmJSyaq, with debug_info, not stripped
bin/tuning: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=EXYzJBlDpVdRos-lXn1e/QcF7ifwzAifyKWqxVgTy/1zohHESm8kL8bY4bV0SA/5YOFqf1WlgC4SQgodypL, with debug_info, not stripped
bin/vlan: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=awfJlZVBkBQOpa7K9jea/wC3AizzB9mtisdvEa2wG/kUKtIL_8rwZZ3K7ZjcTz/iFakbe0hdSBxFkuLkpUZ, with debug_info, not stripped
bin/vrf: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=hVLe5ch6bEAGjNcDsAM4/VLoTJR1MYJv690HcE12H/HqIf8whl0r4DNl-c44ym/tDZVYe9msjIDbcj9d5nA, with debug_info, not stripped
```
manual go-assert-boring validation
```
/go/src/github.com/containernetworking/plugins # for f in bin/*; do go-assert-boring.sh $f;done
bin/flannel: missing goboring symbols
bin/loopback: missing goboring symbols
bin/sbr: missing goboring symbols
bin/static: missing goboring symbols
bin/tuning: missing goboring symbols
bin/vrf: missing goboring symbols
```
manual go-assert-boring with crypto filter
```
/go/src/github.com/containernetworking/plugins # for file in bin/*; do if [ $(go tool nm $file | grep crypto | wc -l) != 0 ]; then go-assert-boring.sh $file; fi; done
/go/src/github.com/containernetworking/plugins # 
```
</details> 