### PR TITLE
Remove s390 build on drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -109,55 +109,6 @@ volumes:
 ---
 kind: pipeline
 type: docker
-name: linux-s390x
-
-platform:
-  os: linux
-  arch: amd64
-
-node:
-  arch: s390x
-
-steps:
-- name: build
-  pull: always
-  image: rancher/hardened-build-base:v1.20.7b3
-  commands:
-  - make DRONE_TAG=${DRONE_TAG}
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-  when:
-    ref:
-      include:
-      - refs/heads/main
-      - refs/pull/**
-      - refs/tags/*
-
-- name: publish
-  image: rancher/hardened-build-base:v1.20.7b3
-  commands:
-  - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  - make DRONE_TAG=${DRONE_TAG} image-push
-  environment:
-    DOCKER_PASSWORD:
-      from_secret: docker_password
-    DOCKER_USERNAME:
-      from_secret: docker_username
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-  when:
-    event:
-    - tag
-
-volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
----
-kind: pipeline
-type: docker
 name: manifest
 platform:
   os: linux
@@ -178,5 +129,4 @@ steps:
 depends_on:
 - linux-amd64
 - linux-arm64
-- linux-s390x
 ...

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -10,8 +10,3 @@ manifests:
     platform:
       architecture: arm64
       os: linux
-  -
-    image: rancher/hardened-cni-plugins:{{build.tag}}-s390x
-    platform:
-      architecture: s390x
-      os: linux


### PR DESCRIPTION
Since s390x is disabled in drone, we should remove the drone manifest for s390x