### PR TITLE
Use bci-busybox as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ARCH="amd64"
 ARG TAG="v1.4.0"
 ARG FLANNEL_TAG="v1.4.0-flannel1"
-ARG BCI_IMAGE=registry.suse.com/bci/bci-base
+ARG BCI_IMAGE=registry.suse.com/bci/bci-busybox
 ARG GO_IMAGE=rancher/hardened-build-base:v1.20.7b3
 ARG GOEXPERIMENT=boringcrypto
 


### PR DESCRIPTION
Same change as in https://github.com/rancher/image-build-cni-plugins/pull/27

We can't use scratch because we are executing a bash script