### PR TITLE
Bump plugins version to v1.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ARCH="amd64"
-ARG TAG="v1.4.0"
+ARG TAG=v1.4.0
 ARG FLANNEL_TAG="v1.4.0-flannel1"
 ARG BCI_IMAGE=registry.suse.com/bci/bci-busybox
 ARG GO_IMAGE=rancher/hardened-build-base:v1.20.7b3
@@ -8,7 +8,7 @@ ARG GOEXPERIMENT=boringcrypto
 ### Build the cni-plugins ###
 FROM ${GO_IMAGE} as cni_plugins
 ARG ARCH
-ARG TAG
+ARG TAG=v1.4.0
 ARG FLANNEL_TAG
 ARG GOEXPERIMENT
 RUN git clone --depth=1 https://github.com/containernetworking/plugins.git $GOPATH/src/github.com/containernetworking/plugins && \


### PR DESCRIPTION



<Actions>
    <action id="d0d74959ef47a6c2808d8fe207b4ff2c1e6540af9bfda1fea292c7a6d8cdabd1">
        <h3>Update plugins version</h3>
        <details id="254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacf">
            <summary>Bump to latest plugins version in Dockerfile</summary>
            <p>changed lines [2 11] of file &#34;/tmp/updatecli/github/rancher/image-build-cni-plugins/Dockerfile&#34;</p>
            <details>
                <summary>v1.4.0</summary>
                <pre>&#xA;Release published on the 2023-12-04 17:00:21 +0000 UTC at the url https://github.com/containernetworking/plugins/releases/tag/v1.4.0&#xA;&#xA;### New features:&#xD;&#xA;- ([#832](https://github.com/containernetworking/plugins/pull/832)). tap: allow for a tap device to be created as a bridge port&#xD;&#xA;- ([#914](https://github.com/containernetworking/plugins/pull/914)). [tuning] add ability to set tx queue len&#xD;&#xA;&#xD;&#xA;### Improvements:&#xD;&#xA;- ([#969](https://github.com/containernetworking/plugins/pull/969)). Add CNI_NETNS_OVERRIDE&#xD;&#xA;- ([#979](https://github.com/containernetworking/plugins/pull/979)). Add ndisc_notify in ipvlan for ipv6 ndp&#xD;&#xA;- ([#974](https://github.com/containernetworking/plugins/pull/974)). macvlan: enable ipv6 ndisc_notify&#xD;&#xA;- ([#950](https://github.com/containernetworking/plugins/pull/950)). Create IPAM files with 0600 permissions&#xD;&#xA;- ([#924](https://github.com/containernetworking/plugins/pull/924)). More efficient iptables usage.&#xD;&#xA;- ([#902](https://github.com/containernetworking/plugins/pull/902)). spoofcheck: Make use of go-nft&#39;s ApplyConfigEcho(). This is much faster&#xD;&#xA;- ([#874](https://github.com/containernetworking/plugins/pull/874)). Add routes propagation for VRF plugin&#xD;&#xA;&#xD;&#xA;### Build:&#xD;&#xA;- ([#982](https://github.com/containernetworking/plugins/pull/982)). Bump to golang:1.21-alpine&#xD;&#xA;- ([#948](https://github.com/containernetworking/plugins/pull/948)). build: Use POSIX sh for shell scripts&#xD;&#xA;&#xD;&#xA;### Bug fixes:&#xD;&#xA;- ([#954](https://github.com/containernetworking/plugins/pull/954)). macvlan cmdDel: handle deletion when master has been deleted&#xD;&#xA;- ([#927](https://github.com/containernetworking/plugins/pull/927)). vrf: fix route filter to use output iface</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

