### PR TITLE
Fix drone manifest

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -47,6 +47,12 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/main
+      - refs/pull/**
+      - refs/tags/*
 
 volumes:
 - name: docker
@@ -70,6 +76,12 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/main
+      - refs/pull/**
+      - refs/tags/*
 
 - name: publish
   image: rancher/hardened-build-base:v1.20.7b3


### PR DESCRIPTION
The scan action should only be executed if there has been a build. This PR fixes this CI problem: https://github.com/rancher/image-build-cni-plugins/pull/36