### PR TITLE
fix: compile all plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,33 +7,43 @@ ARG ARCH="amd64"
 FROM --platform=$BUILDPLATFORM rancher/mirrored-tonistiigi-xx:1.3.0 as xx
 
 ### Build the cni-plugins ###
-FROM --platform=$BUILDPLATFORM ${GO_IMAGE} as cni_plugins_builder
+FROM --platform=$BUILDPLATFORM ${GO_IMAGE} as base_builder
 # copy xx scripts to your build stage
 COPY --from=xx / /
 RUN apk add file make git clang lld
 ARG TARGETPLATFORM
 # setup required packages
 RUN set -x && \
-    xx-apk --no-cache add musl-dev gcc lld 
+    xx-apk --no-cache add musl-dev gcc 
 
+FROM base_builder as cni_plugins_builder
 ARG TAG=v1.4.1
 ARG FLANNEL_TAG=v1.4.0-flannel1
 ARG GOEXPERIMENT
+#clone and get dependencies
 RUN git clone --depth=1 https://github.com/containernetworking/plugins.git $GOPATH/src/github.com/containernetworking/plugins && \
     cd $GOPATH/src/github.com/containernetworking/plugins && \
     git fetch --all --tags --prune && \
-    git checkout tags/${TAG} -b ${TAG} && \
-    xx-go --wrap\
-    sh -ex ./build_linux.sh -v \
-        -gcflags=-trimpath=/go/src \
-        -ldflags " \
-            -X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=${TAG} \
-            -linkmode=external -extldflags \"-static -Wl,--fatal-warnings\" \
-        "
+    git checkout tags/${TAG} -b ${TAG} &&\
+    go mod download
+
 RUN git clone --depth=1 https://github.com/flannel-io/cni-plugin $GOPATH/src/github.com/flannel-io/cni-plugin && \
     cd $GOPATH/src/github.com/flannel-io/cni-plugin && \
     git fetch --all --tags --prune && \
     git checkout tags/${FLANNEL_TAG} -b ${FLANNEL_TAG} && \
+    go mod download 
+ARG TARGETPLATFORM
+ENV CGO_ENABLED=1
+# cross-compile cni-plugins
+RUN cd $GOPATH/src/github.com/containernetworking/plugins && \
+    GO=xx-go sh -ex ./build_linux.sh -v \
+    -gcflags=-trimpath=/go/src \
+    -ldflags " \
+        -X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=${TAG} \
+        -linkmode=external -extldflags \"-static -Wl,--fatal-warnings\" \
+    "
+# cross-compile flannel
+RUN cd $GOPATH/src/github.com/flannel-io/cni-plugin && \
     export GOOS=$(xx-info os) &&\
     export GOARCH=$(xx-info arch) &&\
     export ARCH=$(xx-info arch) &&\
@@ -66,7 +76,7 @@ COPY --from=cni_plugins_builder /opt/cni/ /opt/cni/
 RUN for plugin in $(ls /opt/cni/bin); do \
         strip /opt/cni/bin/${plugin}; \
     done
-    
+
 
 # Create image with the cni-plugins
 FROM ${BCI_IMAGE}


### PR DESCRIPTION
`xx-go --wrap` is not compatible with the `build_linux.sh` script so the plugins were not actually built.
