### PR TITLE
Update go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BCI_IMAGE=registry.suse.com/bci/bci-busybox
-ARG GO_IMAGE=rancher/hardened-build-base:v1.20.14b1
+ARG GO_IMAGE=rancher/hardened-build-base:v1.21.8b1
 ARG GOEXPERIMENT=boringcrypto
 ARG ARCH="amd64"
 


### PR DESCRIPTION
Flannel-cni is using 1.21 and upstream plugins 1.20. As a consequence, now we get errors when building: https://github.com/rancher/image-build-cni-plugins/actions/runs/9258572868/job/25490803483. Moving the version to 1.21 fixes those errors