### PR TITLE
updatecli: use `semver` versionfilter

### DIFF
--- a/updatecli/updatecli.d/updateflannel.yaml
+++ b/updatecli/updatecli.d/updateflannel.yaml
@@ -14,7 +14,8 @@ sources:
        draft: false
        prerelease: false
      versionfilter:
-       kind: latest
+       kind: regex
+       pattern: "v[0-9]+.[0-9]+.[0-9]+-flannel[0-9]+"
 
 targets:
   dockerfile:

--- a/updatecli/updatecli.d/updateplugins.yaml
+++ b/updatecli/updatecli.d/updateplugins.yaml
@@ -14,7 +14,7 @@ sources:
        draft: false
        prerelease: false
      versionfilter:
-       kind: latest
+       kind: semver
 
 targets:
   dockerfile:


### PR DESCRIPTION
Version bump PRs should use the semver instead of the latest tag

Issue: https://github.com/rancher/rke2/issues/6402