### PR TITLE
Bump go version to fix GO-2024-3106

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BCI_IMAGE=registry.suse.com/bci/bci-busybox
-ARG GO_IMAGE=rancher/hardened-build-base:v1.21.11b3
+ARG GO_IMAGE=rancher/hardened-build-base:v1.22.7b1
 ARG GOEXPERIMENT=boringcrypto
 ARG ARCH="amd64"
 
@@ -18,7 +18,7 @@ RUN set -x && \
 
 FROM base_builder as cni_plugins_builder
 ARG TAG=v1.5.1
-ARG FLANNEL_TAG=v1.5.1-flannel2
+ARG FLANNEL_TAG=v1.5.1-flannel3
 ARG GOEXPERIMENT
 #clone and get dependencies
 RUN git clone --depth=1 https://github.com/containernetworking/plugins.git $GOPATH/src/github.com/containernetworking/plugins && \


### PR DESCRIPTION
Bump hardened-build-base and FLANNEL_TAG to versions that use 1.22.7 which contains the fix for the CVE