### PR TITLE
bond-cni: Add --unshallow to git fetch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN git clone --depth=1 https://github.com/containernetworking/plugins.git $GOPA
 
 RUN git clone --depth=1 https://github.com/k8snetworkplumbingwg/bond-cni.git $GOPATH/src/github.com/k8snetworkplumbingwg/bond-cni && \
     cd $GOPATH/src/github.com/k8snetworkplumbingwg/bond-cni && \
-    git fetch --all --tags --prune && \
+    git fetch --unshallow --all --tags --prune && \
     git checkout ${BOND_COMMIT}
 
 RUN git clone --depth=1 https://github.com/flannel-io/cni-plugin $GOPATH/src/github.com/flannel-io/cni-plugin && \


### PR DESCRIPTION
Without --unshallow, checking out the commit can fail because the whole history has not been retrieved.