### PR TITLE
Override golang.org/x/net@v0.56.0 and golang.org/x/sys@v0.44.0 to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,18 +20,21 @@ ARG TAG=v1.9.1
 ARG FLANNEL_TAG=v1.9.1-flannel2
 ARG BOND_COMMIT=258926ad54a78e3dc070ab416cf79055e79c279a
 ARG GOEXPERIMENT
+COPY go-mod-overrides /go-mod-overrides
 #clone and get dependencies
 RUN git clone --depth=1 https://github.com/containernetworking/plugins.git $GOPATH/src/github.com/containernetworking/plugins && \
     cd $GOPATH/src/github.com/containernetworking/plugins && \
     git fetch --all --tags --prune && \
     git checkout tags/${TAG} -b ${TAG} &&\
-    go mod download
+    go mod download && \
+    go-mod-overrides.sh /go-mod-overrides
 
 RUN git clone --depth=1 https://github.com/k8snetworkplumbingwg/bond-cni.git $GOPATH/src/github.com/k8snetworkplumbingwg/bond-cni && \
     cd $GOPATH/src/github.com/k8snetworkplumbingwg/bond-cni && \
     git fetch --unshallow --all --tags --prune && \
     git checkout ${BOND_COMMIT} && \
-    go mod vendor
+    go mod vendor && \
+    go-mod-overrides.sh /go-mod-overrides
 
 RUN git clone --depth=1 https://github.com/flannel-io/cni-plugin $GOPATH/src/github.com/flannel-io/cni-plugin && \
     cd $GOPATH/src/github.com/flannel-io/cni-plugin && \

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,0 +1,9 @@
+# golang.org/x/net: CVE-2026-25680/25681/27136/42502/42506 (x/net/html XSS & DoS),
+# CVE-2025-47911/58190 (x/net/html parsing), CVE-2026-33814 (net/http2 DoS),
+# CVE-2026-39821 (x/net/idna punycode), CVE-2026-46600 (x/net/dns/dnsmessage panic).
+# Drop once upstream requires golang.org/x/net >= v0.56.0.
+-replace golang.org/x/net=golang.org/x/net@v0.56.0
+
+# golang.org/x/sys: CVE-2026-39824 (integer overflow in NewNTUnicodeString in golang.org/x/sys/windows).
+# Drop once upstream requires golang.org/x/sys >= v0.44.0.
+-replace golang.org/x/sys=golang.org/x/sys@v0.44.0


### PR DESCRIPTION
## What this does

Resolves the vulnerabilities reported by Trivy against `rancher/hardened-cni-plugins:v1.9.1-build20260709` (found across the `dhcp`, `bond`, `bridge`, and other `opt/cni/bin/*` binaries):

| Library | Vulnerabilities | Installed | Fixed |
| --- | --- | --- | --- |
| `golang.org/x/net` | CVE-2026-25680, CVE-2026-25681, CVE-2026-27136, CVE-2026-42502, CVE-2026-42506, CVE-2025-47911, CVE-2025-58190, CVE-2026-33814, CVE-2026-39821, CVE-2026-46600 | v0.43.0 | v0.56.0 |
| `golang.org/x/sys` | CVE-2026-39824 (integer overflow in `NewNTUnicodeString` in `golang.org/x/sys/windows`) | v0.35.0 / v0.38.0 | v0.44.0 |

### Changes
This repo did not yet have a `go-mod-overrides` mechanism, so this PR introduces it:
- Add a `go-mod-overrides` file overriding `golang.org/x/net` to `v0.56.0` and `golang.org/x/sys` to `v0.44.0`.
- Wire it into the Dockerfile via `go-mod-overrides.sh` (the standard tool provided by `rancher/hardened-build-base`, used by the other `image-build-*` repos), applied to the two module builds that produce vulnerable binaries:
  - `github.com/containernetworking/plugins` (bandwidth, bridge, dhcp, and the rest — affected by both `x/net` and `x/sys`)
  - `github.com/k8snetworkplumbingwg/bond-cni` (bond — affected by `x/sys`)

The `flannel` binary reported 0 vulnerabilities, so its build (`github.com/flannel-io/cni-plugin`) is left untouched.

These overrides can be dropped once upstream requires `golang.org/x/net >= v0.56.0` and `golang.org/x/sys >= v0.44.0`.

Follows the same approach as rancher/image-build-dns-nodecache#188.