### PR TITLE
Implement missing `exit_with_error` func

### DIFF
--- a/install-cnis.sh
+++ b/install-cnis.sh
@@ -6,7 +6,7 @@ SKIP_CNI_BINARIES=",$SKIP_CNI_BINARIES,"
 UPDATE_CNI_BINARIES=${UPDATE_CNI_BINARIES:-"true"}
 
 exit_with_error() {
-  echo "$1" >&2
+  printf '%s\n' "$*" >&2
   exit 1
 }
 

--- a/install-cnis.sh
+++ b/install-cnis.sh
@@ -5,6 +5,11 @@ SKIP_CNI_BINARIES=${SKIP_CNI_BINARIES:-""}
 SKIP_CNI_BINARIES=",$SKIP_CNI_BINARIES,"
 UPDATE_CNI_BINARIES=${UPDATE_CNI_BINARIES:-"true"}
 
+exit_with_error() {
+  echo "$1" >&2
+  exit 1
+}
+
 # Place the new binaries if the directory is writeable.
 for dir in /host/opt/cni/bin
 do


### PR DESCRIPTION
Issue: https://github.com/rancher/image-build-cni-plugins/issues/221