### PR TITLE
Fix "dangling symlink" error

### DIFF
--- a/install-cnis.sh
+++ b/install-cnis.sh
@@ -32,6 +32,6 @@ do
       echo "$dir/$filename is already here and UPDATE_CNI_BINARIES isn't true, skipping"
       continue
     fi
-    cp "$path" $dir/ && echo "copied $path to $dir correctly" || exit_with_error "Failed to copy $path to $dir. This may be caused by selinux configuration on the host, or something else."
+    cp -v --remove-destination "${path}" "${dir}/${filename}.tmp" && mv -v "${dir}/${filename}.tmp" "${dir}/${filename}" || exit_with_error "Failed to copy $path into $dir. This may be caused by selinux configuration on the host, or something else."
   done
 done


### PR DESCRIPTION
Remove target cni bin before replacing, to avoid failing on dangling(broken) symlinks. This commonly occurs on K3s where the existing CNI bins are symlinks to a path that the cni-plugins container does not have mounted.